### PR TITLE
added for all modules

### DIFF
--- a/content/8188gu-blacklist/README.md
+++ b/content/8188gu-blacklist/README.md
@@ -28,7 +28,7 @@ CPU cycles.
 If you'd rather NOT remove the dongle, you can simply blacklist the module from loading
 in the first place. To do so, execute this simple one liner to create the this file:
 
-`sudo bash -c "echo 'blacklist 8188eu' > /etc/modprobe.d/blacklist-8188gu.conf"`
+`sudo bash -c "echo 'blacklist 8188*' > /etc/modprobe.d/blacklist-8188gu.conf"`
 
 Once complete, restart your Plus4.
 


### PR DESCRIPTION
Someone reported in the discord they were still impacted by cpu performance after blacklisting modules. They must have a different dongle because it was using a different module than I had. Basically, the format is 8188XX, xx being unique to the chipset. This addition allows for ANY 8188 module to be blacklisted for folks who don't use wifi. 