### PR TITLE
fw v1.6 - disabling the chamber heater bed state check in heaters.py

### DIFF
--- a/content/tuning-for-40-percent-heater-power/README.md
+++ b/content/tuning-for-40-percent-heater-power/README.md
@@ -2,8 +2,9 @@
 
 ## Introduction
 
-**Update**:  *Do not use this warmup sequence on v1.6.0 or later firmware as it clashes with chamber heater behavior changes that
-Qidi introduced with their 1.6.0 update. *
+> **⚠️ Caution:** *For firmware v1.6.0 or later, you have two choices:*
+> 1. *Don't use this warmup sequence at all.*
+> 2. *Use the [Improved PRINT_START macro](#Improved-PRINT_START-macro) in addition to the steps detailed in [Firmware v1.6.0 - Required Steps](#firmware-v160---required-steps).*
 
 ***
 
@@ -49,7 +50,7 @@ It was observed that it took 25 minutes to the time that the bed meshing started
 A time of 19m30s was observed to the time that the bed meshing started.
 
 
-## So, what's the configuration changes you did?
+## Improved PRINT_START macro
 
 Change the `PRINT_START` macro within `gcode_macro.cfg` to the following in its entirety.
 I've added detailed comments to (almost) every line so it is easier to understand what all
@@ -146,3 +147,61 @@ If this feature is active, then the slicer will instruct the printer to attempt 
 and there are reports that this can take up to 1 hour for the chamber to reach 60C.
 
 ![DISABLE THIS!](./disable-me.png "You REALLY don't want this enabled!")
+
+## Firmware v1.6.0 - Required Steps
+
+> **⚠️ Caution:** Do not follow these steps if on firmware earlier than v1.6.0
+
+### Modifying heaters.py
+
+1. SSH into the printer
+2. Write a new file named ```heaters.patch``` with these contents:
+```.patch
+--- a/klippy/extras/heaters.py
++++ b/klippy/extras/heaters.py
+@@ -234,7 +234,10 @@ class ControlPID:
+         #logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f co=%d",
+         #    temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ, co)
+         bounded_co = max(0., min(self.heater_max_power, co))
+-        if self.heater.name == "chamber" and heater_bed.heater_bed_state != 2 and heater_bed.is_heater_bed == 1:
++        # We add this DISABLE_BED_CHECK flag so that the chamber heater can be controlled independently of the bed heater
++        # This should not be used in normal operation with the stock piezo sensor
++        DISABLE_BED_CHECK = True
++        if self.heater.name == "chamber" and heater_bed.heater_bed_state != 2 and heater_bed.is_heater_bed == 1 and not DISABLE_BED_CHECK:
+             self.heater.set_pwm(read_time, 0.)
+         else:
+             self.heater.set_pwm(read_time, bounded_co)
+-- 
+
+```
+3. Apply the patch ```patch /home/mks/klipper/klippy/extras/heaters.py < /path/to/heaters.patch```
+4. If that was succesfull you will see something like ```patching file heaters.py```
+
+### Explanation
+
+We have modified the code in heaters.py to add a ```DISABLE_BED_CHECK = True``` flag. 
+Where normally the chamber heater does not turn on unless the bed is within 2 degrees of the target bed temp, we ignore this using our new flag.
+Set ```DISABLE_BED_CHECK = False``` if you want to revert to the default behavior.
+
+```python
+        # We add this DISABLE_BED_CHECK flag so that the chamber heater can be controlled independently of the bed heater
+        # This should not be used in normal operation with the stock piezo sensor
+        DISABLE_BED_CHECK = True
+        if self.heater.name == "chamber" and heater_bed.heater_bed_state != 2 and heater_bed.is_heater_bed == 1 and not DISABLE_BED_CHECK:
+            self.heater.set_pwm(read_time, 0.)
+        else:
+            self.heater.set_pwm(read_time, bounded_co)
+        # Store state for next measurement
+        self.prev_temp = temp
+        self.prev_temp_time = read_time
+        self.prev_temp_deriv = temp_deriv
+        if co == bounded_co:
+            self.prev_temp_integ = temp_integ
+        if self.heater.name == "heater_bed" :
+            if target_temp < 70:
+                heater_bed.heater_bed_state = 0
+            elif temp < target_temp - 2.:
+                heater_bed.heater_bed_state = 1
+            else:
+                heater_bed.heater_bed_state = 2
+```

--- a/content/tuning-for-40-percent-heater-power/README.md
+++ b/content/tuning-for-40-percent-heater-power/README.md
@@ -156,7 +156,10 @@ and there are reports that this can take up to 1 hour for the chamber to reach 6
 
 1. SSH into the printer
 2. Write a new file named ```heaters.patch``` with these contents:
-```.patch
+<details open>
+<summary>Patch for heaters.py</summary>
+
+```patch
 --- a/klippy/extras/heaters.py
 +++ b/klippy/extras/heaters.py
 @@ -234,7 +234,10 @@ class ControlPID:
@@ -172,9 +175,12 @@ and there are reports that this can take up to 1 hour for the chamber to reach 6
          else:
              self.heater.set_pwm(read_time, bounded_co)
 -- 
-
 ```
+
+</details>
+
 3. Apply the patch ```patch /home/mks/klipper/klippy/extras/heaters.py < /path/to/heaters.patch```
+
 4. If that was succesfull you will see something like ```patching file heaters.py```
 
 ### Explanation


### PR DESCRIPTION
The chamber heater in firmware v1.6.0 uses a heater bed state machine to prevent the chamber heater from turning on early. We can disable this check to enable faster chamber warmup.