### PR TITLE
Comment out shaketune in example printer.cfg

### DIFF
--- a/content/bed-scanning-probes/Beacon3D/RevH-Normal/printer.cfg
+++ b/content/bed-scanning-probes/Beacon3D/RevH-Normal/printer.cfg
@@ -540,8 +540,9 @@ autocal_tolerance: 0.006
 #pin:!PA10
 #z_offset:0
 
-[shaketune]
-timeout: 1200
+# Uncomment this if you have shaketune installed
+#[shaketune]
+#timeout: 1200
 
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.


### PR DESCRIPTION
If we're including a sample printer.cfg for beacon, it should probably contain only things we can reasonably assume everybody has (e.g. items from the wiki) -- if shaketune is in there and the user doesn't have shaketune installed it will error on startup.