### PR TITLE
fix: Add QIDI Box on Orcaslicer to the main README, fix variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ of the Qidi Plus4 3D printer.
 
 ### [Orca Slicer Settings](./content/orca-slicer-settings)
 
+### [QIDI Box on Orca Slicer](./content/qidibox-on-orcaslicer)
+
 ---
 
 ## Printable Models

--- a/content/qidibox-on-orcaslicer/README.md
+++ b/content/qidibox-on-orcaslicer/README.md
@@ -10,7 +10,7 @@ PRINT_START BED=[bed_temperature_initial_layer_single] HOTEND=[nozzle_temperatur
 ```
 To:
 ```
-PRINT_START BED=[bed_temperature_initial_layer_single] HOTEND=[nozzle_temperature_initial_layer] CHAMBER=[chamber_temperatures] EXTRUDER=[initial_no_support_extruder]
+PRINT_START BED=[bed_temperature_initial_layer_single] HOTEND=[nozzle_temperature_initial_layer] CHAMBER=[chamber_temperature] EXTRUDER=[initial_no_support_extruder]
 ```
 
 ---


### PR DESCRIPTION
You did an awesome job! I discovered it by accident — maybe it would be a good idea to place the link somewhere more visible?
Also, I think there's a typo in 'chamber_temperature'.