### PR TITLE
[Adaptive Main Board Cooling] Add stepper temperature monitoring

### DIFF
--- a/content/adaptive-main-board-cooling/README.md
+++ b/content/adaptive-main-board-cooling/README.md
@@ -1,69 +1,98 @@
 # Adaptive Main Board Cooling Configuration
 
 > [!IMPORTANT]
-> If you have previously imported the cofiguration files from [config-xplus4 repo](https://github.com/qidi-community/config-xplus4), then you already have a variation of this configuration installed and active! Verify by accessing the fluidd UI in your web browser and pressing the `x` key on your keyboard and look for a folder called `config-xplus4`. If you do not have it already, you can implement this page as documented. Additionally, installing the `config-xplus4` mods actively conflicts with this guide, so before installing the set of config mods you will have to undo what you did here.
+> If configuration files from the deprecated [config-xplus4](https://github.com/qidi-community/config-xplus4) repository were previously imported, a variation of this configuration is already installed and active. To verify, access the Fluidd UI in a web browser, press the `x` key on the keyboard, and look for a folder called `config-xplus4`. If it is not present, this guide can be implemented as documented. The `config-xplus4` modifications conflict with this guide and must be removed before proceeding.
 
-By default, the main board cooling fan is only active/on when the X/Y stepper motors are active (ie. during printing).
-While this ensures that the printer makes less noise during idle times when not printing, it does allow for the main
-CPU and various components on the main board to get extremely warm.
+## Overview
 
-The following configuration change alters this behaviour.  Instead the mainboard cooling fan will always be active, but
-at a very low speed during idle times to ensure that the mainboard and CPU don't get overly warm.  When the CPU rises
-above a certain set temperature (45C) then the main-board cooling fan speed will be ramped up to try to keep temperatures
-stable.
+By default, the main board cooling fan operates only when the X/Y stepper motors are active (during homing and printing). While this reduces noise during idle periods, it leaves the main board's SoC and various components without adequate cooling.
+
+This configuration provides continuous cooling. The main board fan runs at a low speed (`min_speed`) during idle periods to maintain acceptable temperatures. When the board temperature exceeds the configured `target_temp`, the fan speed increases to maintain thermal stability.
+
+This enhanced version can optionally monitor TMC stepper driver temperatures. The fan speed is determined by the highest temperature reading between the host sensor and any configured stepper drivers. This ensures adequate cooling even when stepper drivers heat up during printing. After steppers are disabled, cooling continues for 2 minutes to allow proper driver cool-down.
 
 > [!TIP]
->   While the below configuration change works well with the stock 40mm fan, it is highly recommended to swap out
-the stock main-board fan and its mainboard cover with an 80mm fan, and a 3D printed mainboard cover that allows for the
-use of the 80mm fan.  Alternatively, a [good 4020 fan](https://www.amazon.com/dp/B0CHYF6S2N) or the 80mm fan mod can move significantly more air while using the stock mainboard cover.
-This ensures that the mainboard, CPU, and steppers drivers are kept cool during both idle times, and when in operation,
-while keeping fan noise to a minimum.
+> While this configuration works with the stock 40mm fan, upgrading to an 80mm fan with a 3D-printed main board cover, or installing a [high-quality 4020 fan](https://www.amazon.com/dp/B0CHYF6S2N) is recommended. These upgrades provide significantly better airflow with minimal noise increase, ensuring optimal cooling for the main board, SoC, and stepper drivers during both idle and active operation.
 
+## Installation Steps
 
-## Editing printer.cfg
+### Step 1: Edit printer.cfg
 
-To edit your `printer.cfg` file, this can typically be done through the FluiddUI Web Page to the printer under the `Configuration` tab.
-Find the file named `printer.cfg` and click on it
-When done editing, press the `SAVE & RESTART` button in the FluiddUI
+Open the Fluidd UI and navigate to the `Configuration` tab. Locate and open the `printer.cfg` file.
 
+#### Comment out the existing controller_fan section
 
-## Per Section Changes
+Locate the `[controller_fan board_fan]` section and comment out all lines:
 
-For each of the mentioned configuration sections within your `printer.cfg` file, find the named fields and change the associated value to the newly specified value.
-
-First find the `[controller_fan board_fan]` section and comment it out like so:
-
+> [!WARNING]  
+> Different firmware versions may have varying lines in the `[controller_fan board_fan]` section. All lines in this section must be commented out, regardless of their content.
 ```
 # [controller_fan board_fan]
-# pin:U_1:PC4
-# max_power:1.0
-# shutdown_speed:1.0
-# cycle_time:0.01
+# pin: U_1:PC4
+# max_power: 1.0
+# shutdown_speed: 1.0
+# cycle_time: 0.01
 # fan_speed: 1.0
-# heater:chamber
-# stepper:stepper_x,stepper_y
+# heater: chamber
+# stepper: stepper_x, stepper_y
 ```
-> [!WARNING]  
-> There have been reports of later firmware versions having additional or less lines to the above `[controller_fan board_fan]` example. Those should also be commented out if they appear in your configuration (ie. the entire `[controller_fan board_fan]` section should be commented out).
 
-Now add the following configuration below the commented out section:
+#### Add the new temperature_fan section
 
+Below the commented-out section, add the following configuration:
 ```
 [temperature_fan board_fan]
-pin:U_1:PC4
+pin: U_1:PC4
+sensor_type: temperature_host
+stepper: stepper_x, stepper_y
+control: pid
+pid_Kp: 5
+pid_Ki: 2
+pid_Kd: 5
+pid_deriv_time: 2.0
+target_temp: 50
+min_temp: 0
+max_temp: 100
+min_speed: 0.3
+max_speed: 1.0
 max_power: 1.0
 shutdown_speed: 1.0
 cycle_time: 0.01
 off_below: 0
-sensor_type: temperature_host
-control: pid
-pid_deriv_time: 2.0
-pid_Kp: 5
-pid_Ki: 2
-pid_Kd: 5
-target_temp: 50
-min_speed: 0.3
-max_speed: 1.0
-min_temp: 0
-max_temp: 100
+```
+
+> [!NOTE]
+> The `stepper` parameter is optional. To monitor only host temperature without stepper driver monitoring, remove the `stepper: stepper_x, stepper_y` line.
+
+#### Save without restarting
+
+Click the `SAVE` button (not `SAVE & RESTART`) to preserve changes without restarting Klipper.
+
+### Step 2: Install the enhanced temperature_fan module
+
+Connect to the printer via SSH and execute the following commands:
+```bash
+cp /home/mks/klipper/klippy/extras/temperature_fan.py /home/mks/klipper/klippy/extras/temperature_fan.py.backup
+wget -O /home/mks/klipper/klippy/extras/temperature_fan.py https://raw.githubusercontent.com/qidi-community/Plus4-Wiki/refs/heads/main/content/adaptive-main-board-cooling/temperature_fan.py
+rm /home/mks/klipper/klippy/extras/__pycache__/temperature_fan*.pyc
+```
+
+### Step 3: Restart Klipper
+```bash
+sudo systemctl restart klipper
+```
+
+The adaptive main board cooling system is now active.
+
+## Restoring Original Configuration
+
+To revert to the original configuration:
+
+1. In `printer.cfg`, remove the `[temperature_fan board_fan]` section and uncomment the `[controller_fan board_fan]` section
+2. Click the `SAVE` button
+3. Connect via SSH and execute:
+```bash
+cp /home/mks/klipper/klippy/extras/temperature_fan.py.backup /home/mks/klipper/klippy/extras/temperature_fan.py
+rm /home/mks/klipper/klippy/extras/__pycache__/temperature_fan*.pyc
+sudo systemctl restart klipper
 ```

--- a/content/adaptive-main-board-cooling/temperature_fan.py
+++ b/content/adaptive-main-board-cooling/temperature_fan.py
@@ -1,0 +1,308 @@
+# Support fans that are enabled when temperature exceeds a set threshold
+#
+# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Modified by AMoo-Miki (2025) - Added stepper temperature monitoring
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+# This software is provided "as is", without warranty of any kind.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+# This software is provided "as is", without warranty of any kind.
+
+# Temperature Fan Control:
+# - Controls fan speed based on a temperature sensor reading
+# - Supports any Klipper temperature sensor type (thermistor, temperature_host, etc.)
+# - Use PID or bang-bang control algorithm to maintain target temperature
+#
+# Stepper Temperature Monitoring (Optional):
+# - Monitors TMC stepper driver temperatures alongside the primary sensor
+# - Use 'stepper' parameter to specify steppers: stepper: stepper_x, stepper_y
+# - Takes the maximum of sensor temp and all stepper temps for fan control
+# - Caches stepper temps for 2 minutes after steppers are disabled to continue cooling
+# - Supports TMC2240, TMC2209, and TMC5160 drivers with temperature reporting
+#
+# Example configuration:
+#
+# [temperature_fan board_fan]
+# pin: U_1:PC4
+# sensor_type: temperature_host          # Primary temperature sensor (any valid Klipper sensor)
+# stepper: stepper_x, stepper_y          # Optional: Monitor these stepper drivers too
+# control: pid                           # Control algorithm: pid or watermark
+# pid_Kp: 5
+# pid_Ki: 2
+# pid_Kd: 5
+# pid_deriv_time: 2.0
+# target_temp: 50                        # Target temperature in Celsius
+# min_temp: 0                            # Minimum safe temperature
+# max_temp: 100                          # Maximum safe temperature
+# min_speed: 0.3                         # Minimum fan speed (0.0 to 1.0)
+# max_speed: 1.0                         # Maximum fan speed (0.0 to 1.0)
+# max_power: 1.0
+# shutdown_speed: 1.0
+# cycle_time: 0.01
+# off_below: 0
+
+from . import fan
+
+KELVIN_TO_CELSIUS = -273.15
+MAX_FAN_TIME = 5.0
+AMBIENT_TEMP = 25.
+PID_PARAM_BASE = 255.
+STEPPER_CACHE_DURATION = 120.  # Keep using stepper temps for 2 minutes after disable
+
+class TemperatureFan:
+    def __init__(self, config):
+        self.name = config.get_name().split()[1]
+
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:connect", self.handle_connect)
+
+        self.stepper_enable = self.printer.load_object(config, 'stepper_enable')
+        self.stepper_names = config.getlist("stepper", None)
+        self.steppers = []
+        self.cached_stepper_temps = {}  # Dict: stepper object -> (temp, timestamp)
+
+        self.fan = fan.Fan(config, default_shutdown_speed=1.)
+        self.min_temp = config.getfloat('min_temp', minval=KELVIN_TO_CELSIUS)
+        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+
+        pheaters = self.printer.load_object(config, 'heaters')
+        self.sensor = pheaters.setup_sensor(config)
+        self.sensor.setup_minmax(self.min_temp, self.max_temp)
+        self.sensor.setup_callback(self.temperature_callback)
+        pheaters.register_sensor(config, self)
+
+        self.speed_delay = self.sensor.get_report_time_delta()
+        self.max_speed_conf = config.getfloat(
+            'max_speed', 1., above=0., maxval=1.)
+        self.max_speed = self.max_speed_conf
+        self.min_speed_conf = config.getfloat(
+            'min_speed', 0.3, minval=0., maxval=1.)
+        self.min_speed = self.min_speed_conf
+
+        self.last_temp = 0.
+        self.last_temp_time = 0.
+        self.target_temp_conf = config.getfloat(
+            'target_temp', 40. if self.max_temp > 40. else self.max_temp,
+            minval=self.min_temp, maxval=self.max_temp)
+        self.target_temp = self.target_temp_conf
+
+        algos = {'watermark': ControlBangBang, 'pid': ControlPID}
+        algo = config.getchoice('control', algos)
+        self.control = algo(self, config)
+
+        self.next_speed_time = 0.
+        self.last_speed_value = 0.
+
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command(
+            "SET_TEMPERATURE_FAN_TARGET", "TEMPERATURE_FAN", self.name,
+            self.cmd_SET_TEMPERATURE_FAN_TARGET,
+            desc=self.cmd_SET_TEMPERATURE_FAN_TARGET_help)
+
+    def handle_connect(self):
+        if self.stepper_names is None:
+            return  # No steppers configured, skip entirely
+
+        all_steppers = self.stepper_enable.get_steppers()
+
+        if not all(x in all_steppers for x in self.stepper_names):
+            raise self.printer.config_error(
+                "One or more of these steppers are unknown: "
+                "%s (valid steppers are: %s)"
+                % (self.stepper_names, ", ".join(all_steppers)))
+
+        if self.stepper_names:
+            for stepper_name in self.stepper_names:
+                stepper = None
+                for tmc_type in ['tmc2240', 'tmc2209', 'tmc5160']:
+                    try:
+                        stepper = self.printer.lookup_object(tmc_type + ' ' + stepper_name)
+                        break
+                    except:
+                        continue
+
+                if stepper is None:
+                    raise self.printer.config_error(
+                        "Stepper %s does not have a TMC driver configured" % stepper_name)
+
+                self.steppers.append(stepper)
+
+    def set_speed(self, read_time, value):
+        if value <= 0.:
+            value = 0.
+        elif value < self.min_speed:
+            value = self.min_speed
+        if self.target_temp <= 0.:
+            value = 0.
+        if ((read_time < self.next_speed_time or not self.last_speed_value)
+                and abs(value - self.last_speed_value) < 0.05):
+            # No significant change in value - can suppress update
+            return
+        speed_time = read_time + self.speed_delay
+        self.next_speed_time = speed_time + 0.75 * MAX_FAN_TIME
+        self.last_speed_value = value
+        self.fan.set_speed(speed_time, value)
+
+    def read_stepper_temps(self):
+        """Read temperatures from all configured TMC steppers and return the maximum"""
+        temps = []
+        eventtime = self.printer.get_reactor().monotonic()
+
+        for stepper in self.steppers:
+            try:
+                status = stepper.get_status(eventtime)
+                temp = None
+
+                # Try different locations where temp might be reported
+                if 'temperature' in status:
+                    temp = status['temperature']
+                elif 'drv_status' in status and 'temperature' in status['drv_status']:
+                    temp = status['drv_status']['temperature']
+
+                if temp is not None:
+                    self.cached_stepper_temps[stepper] = (temp, eventtime)
+                    temps.append(temp)
+                else:
+                    # No valid temp - check cache
+                    if stepper in self.cached_stepper_temps:
+                        cached_temp, cached_time = self.cached_stepper_temps[stepper]
+                        if (eventtime - cached_time) < STEPPER_CACHE_DURATION:
+                            temps.append(cached_temp)
+                        # else: cache expired, don't use it
+            except:
+                pass  # Skip if we can't read this stepper
+
+        return temps
+
+    def temperature_callback(self, read_time, temp):
+        # Get max stepper temperature
+        stepper_temps  = self.read_stepper_temps()
+        all_temps = [temp] + stepper_temps
+        self.last_temp = max(all_temps)
+        self.control.temperature_callback(read_time, self.last_temp)
+
+    def get_temp(self, eventtime):
+        return self.last_temp, self.target_temp
+
+    def get_min_speed(self):
+        return self.min_speed
+
+    def get_max_speed(self):
+        return self.max_speed
+
+    def get_status(self, eventtime):
+        status = self.fan.get_status(eventtime)
+        status["temperature"] = round(self.last_temp, 2)
+        status["target"] = self.target_temp
+        return status
+    cmd_SET_TEMPERATURE_FAN_TARGET_help = \
+        "Sets a temperature fan target and fan speed limits"
+    def cmd_SET_TEMPERATURE_FAN_TARGET(self, gcmd):
+        temp = gcmd.get_float('TARGET', self.target_temp_conf)
+        self.set_temp(temp)
+        min_speed = gcmd.get_float('MIN_SPEED', self.min_speed)
+        max_speed = gcmd.get_float('MAX_SPEED', self.max_speed)
+        if min_speed > max_speed:
+            raise self.printer.command_error(
+                "Requested min speed (%.1f) is greater than max speed (%.1f)"
+                % (min_speed, max_speed))
+        self.set_min_speed(min_speed)
+        self.set_max_speed(max_speed)
+
+    def set_temp(self, degrees):
+        if degrees and (degrees < self.min_temp or degrees > self.max_temp):
+            raise self.printer.command_error(
+                "Requested temperature (%.1f) out of range (%.1f:%.1f)"
+                % (degrees, self.min_temp, self.max_temp))
+        self.target_temp = degrees
+
+    def set_min_speed(self, speed):
+        if speed and (speed < 0. or speed > 1.):
+            raise self.printer.command_error(
+                "Requested min speed (%.1f) out of range (0.0 : 1.0)"
+                % (speed))
+        self.min_speed = speed
+
+    def set_max_speed(self, speed):
+        if speed and (speed < 0. or speed > 1.):
+            raise self.printer.command_error(
+                "Requested max speed (%.1f) out of range (0.0 : 1.0)"
+                % (speed))
+        self.max_speed = speed
+
+######################################################################
+# Bang-bang control algo
+######################################################################
+
+class ControlBangBang:
+    def __init__(self, temperature_fan, config):
+        self.temperature_fan = temperature_fan
+        self.max_delta = config.getfloat('max_delta', 2.0, above=0.)
+        self.heating = False
+        
+    def temperature_callback(self, read_time, temp):
+        current_temp, target_temp = self.temperature_fan.get_temp(read_time)
+        if (self.heating
+                and temp >= target_temp+self.max_delta):
+            self.heating = False
+        elif (not self.heating
+              and temp <= target_temp-self.max_delta):
+            self.heating = True
+        if self.heating:
+            self.temperature_fan.set_speed(read_time, 0.)
+        else:
+            self.temperature_fan.set_speed(read_time,
+                                           self.temperature_fan.get_max_speed())
+
+######################################################################
+# Proportional Integral Derivative (PID) control algo
+######################################################################
+
+PID_SETTLE_DELTA = 1.
+PID_SETTLE_SLOPE = .1
+
+class ControlPID:
+    def __init__(self, temperature_fan, config):
+        self.temperature_fan = temperature_fan
+        self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
+        self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
+        self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.min_deriv_time = config.getfloat('pid_deriv_time', 2., above=0.)
+        self.temp_integ_max = 0.
+        if self.Ki:
+            self.temp_integ_max = self.temperature_fan.get_max_speed() / self.Ki
+        self.prev_temp = AMBIENT_TEMP
+        self.prev_temp_time = 0.
+        self.prev_temp_deriv = 0.
+        self.prev_temp_integ = 0.
+        
+    def temperature_callback(self, read_time, temp):
+        current_temp, target_temp = self.temperature_fan.get_temp(read_time)
+        time_diff = read_time - self.prev_temp_time
+        # Calculate change of temperature
+        temp_diff = temp - self.prev_temp
+        if time_diff >= self.min_deriv_time:
+            temp_deriv = temp_diff / time_diff
+        else:
+            temp_deriv = (self.prev_temp_deriv * (self.min_deriv_time-time_diff)
+                          + temp_diff) / self.min_deriv_time
+        # Calculate accumulated temperature "error"
+        temp_err = target_temp - temp
+        temp_integ = self.prev_temp_integ + temp_err * time_diff
+        temp_integ = max(0., min(self.temp_integ_max, temp_integ))
+        # Calculate output
+        co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
+        bounded_co = max(0., min(self.temperature_fan.get_max_speed(), co))
+        self.temperature_fan.set_speed(
+            read_time, max(self.temperature_fan.get_min_speed(),
+                           self.temperature_fan.get_max_speed() - bounded_co))
+        # Store state for next measurement
+        self.prev_temp = temp
+        self.prev_temp_time = read_time
+        self.prev_temp_deriv = temp_deriv
+        if co == bounded_co:
+            self.prev_temp_integ = temp_integ
+
+def load_config_prefix(config):
+    return TemperatureFan(config)


### PR DESCRIPTION
## Enhanced Main Board Cooling with Stepper Temperature Monitoring

This change provides comprehensive thermal management for the main board, SoC, and stepper drivers with a single, unified fan control configuration.

The current `temperature_fan` implementation has limitations when used for main board cooling:

**Using only `temperature_host` (SoC temperature):**
- Does not account for stepper driver heat, which can be significant during printing
- Stepper drivers can reach high temperatures independently of the SoC
- Fan may run at low speed while drivers overheat, or vice versa
- Results in inadequate cooling for one component or the other

**Using only stepper-based cooling (e.g., `controller_fan`):**
- Fan only runs when steppers are enabled (during homing/printing)
- No cooling during idle periods, allowing SoC and board components to heat up
- All-or-nothing approach: full speed when active, off when idle
- No temperature-based control or PID regulation

### Solution

This enhancement adds optional stepper temperature monitoring to `temperature_fan`, combining the best of both approaches:

1. **Multi-source temperature monitoring**: Monitors both host sensor and TMC stepper driver temperatures
2. **Maximum temperature control**: Fan speed is controlled by whichever temperature is highest
3. **Continuous operation**: Fan runs at `min_speed` during idle, increases based on actual thermal load
4. **PID control**: Smooth, regulated fan speed based on temperature rather than on/off operation
5. **Post-disable cooling**: Caches stepper temperatures for 2 minutes after steppers disable, ensuring proper driver cool-down

### Implementation Details

- Added optional `stepper` parameter to specify which steppers to monitor
- Supports TMC2240, TMC2209, and TMC5160 drivers with temperature reporting
- Per-stepper temperature caching with individual 2-minute windows
- Backward compatible: if `stepper` parameter is omitted, operates exactly as before
- Zero performance impact when stepper monitoring is not configured

