### PR TITLE
fix PermitRootLogin instructions

### DIFF
--- a/content/ssh-security/README.md
+++ b/content/ssh-security/README.md
@@ -62,10 +62,10 @@ Edit the file found at `/etc/ssh/sshd_config` with `sudo` privileges:
 sudo nano /etc/ssh/sshd_config
 ```
 
-Find the line beginning with `PermitRootLogin` and change "on" to "off". Your end result should look like the below. Mine was found on line 32.
+Find the line beginning with `PermitRootLogin` and change "yes" to "no". Your end result should look like the below. Mine was found on line 32.
 
 ```
-PermitRootLogin off
+PermitRootLogin no
 ```
 
 Save and exit. Restart the `ssh` daemon with:


### PR DESCRIPTION
The current 'ssh-security' instructions shows the wrong line of code for disabling root ssh login, in the sshd_config file.

**Issue Description**
The ssh-security readme page currently suggests modifying your sshd_config to have the line 
```
PermitRootLogin off
```
but this is an invalid setting. The only valid arguments  for `PermitRootLogin` are `yes`, `no`, `prohibit-password`, or `forced-commands-only`. See https://manpages.debian.org/buster/openssh-server/sshd_config.5.en.html

Following the current instructions will make the sshd_config file invalid, causing the ssh daemon to fail to start. This prevents any further ssh connections to the machine until the sshd_config file is fixed (which becomes more difficult when you can't ssh into the machine anymore!)