### PR TITLE
Inductive probe EMI from extruder heater PWM

### DIFF
--- a/content/inductive-probe-emi/README.md
+++ b/content/inductive-probe-emi/README.md
@@ -16,22 +16,61 @@ This problem was on the original unit and on the Phaetus Conch.
 2. Use a different type of sensor.
 3. Turn off the extruder heater while the sensor is operating.
 
-### Disable heater while meshing
+### Disable extruder heater while probing
 
-Meshing is the primary application of an inductive sensor, which uses a small number of measurements per point (2 by default). Everything else has a higher number of measurements and is therefore less susceptible to interference.
-We'll disable the heater only during meshing.
+Founded what `smart_effector` can run custom gcode before and after probe.
 
-1. Backup `gcode_macro.cfg`
-2. Edit `gcode_macro.cfg`
-3. Find `[gcode_macro G29]`
-4. Insert new lines before (disable heater) and after (restore temp) calling meshing:
+For changes has 2 options to write changes:
+1. To end of `printer.cfg`
+2. To separate `.cfg` file in printer config folder, and include in end of printer.cfg:
 ```
-        M104 S0 # new line added - disable extruder heater
-        BED_MESH_CALIBRATE PROFILE=kamp
-        M109 S104 # new line added - restore heater to 140c
+[include my_custom_config.cfg]
 ```
+
+Custom gcode:
 ```
-            M104 S0 # new line added - disable extruder heater
-            _BED_MESH_CALIBRATE PROFILE=default
-            M109 S104 # new line added - restore heater to 140c
+#-------- probe heaters activate/deactivate ---------
+[gcode_macro _PROBE_HEATERS_ACTIVATE]
+description: Induction sensor/probe activate heaters
+variable_extruder_temp: 0
+gcode:
+    {% if extruder_temp > 0 %}
+        M104 S{extruder_temp} # extruder
+    {% endif %}
+
+    
+[gcode_macro _PROBE_HEATERS_DEACTIVATE]
+description: Induction sensor/probe deactivate heaters for EMI
+gcode:
+    SET_GCODE_VARIABLE MACRO=_PROBE_HEATERS_ACTIVATE VARIABLE=extruder_temp VALUE={printer["extruder"].target}
+    M104 S0 # extruder
+
+[smart_effector]
+deactivate_on_each_sample: True
+activate_gcode:
+    _PROBE_HEATERS_ACTIVATE
+deactivate_gcode:
+    _PROBE_HEATERS_DEACTIVATE
+```
+
+### Optional additional config
+
+After changes my printers have good repeatability of measurements. I use bigger mesh and lower probe tolerance like on [Better Bed Meshing](../more-accurate-bed-meshing/README.md), and tested what:
+1. No motors tweaks need anymore, but i still use "interpolate: False".
+2. Probe z-speeds can bee increased back to default (5), lift-speed - more then default.
+3. In my case 5 samples per point has "99%" difference in values >0.08 and near measurement points while meshing has adequate difference. I think it safe to decrease probe to 1 sample, but i keep use default 2 for testing. 
+
+```
+# Bigger mesh
+[bed_mesh]
+horizontal_move_z:10
+probe_count:11,11
+bicubic_tension:0.3
+
+[smart_effector]
+speed:5
+lift_speed: 10
+samples: 2
+sample_retract_dist: 10
+samples_tolerance: 0.013
 ```

--- a/content/inductive-probe-emi/README.md
+++ b/content/inductive-probe-emi/README.md
@@ -1,0 +1,34 @@
+# Inductive probe EMI
+
+I have two printers: one generates a relatively normal bed map, while the other doesn't. The inductive sensor sometimes triggers almost "randomly." The bed map is significantly distorted, and it can be measured at the cost of very large point repetitions.
+
+I've noticed that the situation changes significantly during head maintenance, and that the problem depends on the location of the sensor cable.
+
+The original cable is unshielded and without twisted pair. However, the extruder heater is always running, holding the PWM at 140 degrees (to stabilize for piezoelectric sensor measurements).
+
+Disabling the heater during mesh construction stopped the random sensor activations and reduced its reading repeatability to 0.05 mm. Apparently, the inductive sensor cable is picking up interference from the heater's PWM controller.
+
+This problem was on the original unit and on the Phaetus Conch.
+
+## Possible solutions
+
+1. Route the sensor cable away from the heater cables. It should also be secured to prevent vibration during printing.
+2. Use a different type of sensor.
+3. Turn off the extruder heater while the sensor is operating.
+
+### Disable heater while meshing
+
+1. Backup `gcode_macro.cfg`
+2. Edit `gcode_macro.cfg`
+3. Find `[gcode_macro G29]`
+4. Insert new lines before (disable heater) and after (restore temp) calling meshing:
+```
+        M104 S0 # new line added - disable extruder heater
+        BED_MESH_CALIBRATE PROFILE=kamp
+        M109 S104 # new line added - restore heater to 140c
+```
+```
+            M104 S0 # new line added - disable extruder heater
+            _BED_MESH_CALIBRATE PROFILE=default
+            M109 S104 # new line added - restore heater to 140c
+```

--- a/content/inductive-probe-emi/README.md
+++ b/content/inductive-probe-emi/README.md
@@ -1,12 +1,12 @@
 # Inductive probe EMI
 
-I have two printers: one generates a relatively normal bed map, while the other doesn't. The inductive sensor sometimes triggers almost "randomly." The bed map is significantly distorted, and it can be measured at the cost of very large point repetitions.
+The inductive sensor sometimes triggers almost "randomly." The bed map is significantly distorted, and it can be measured at the cost of very large point repetitions.
 
 I've noticed that the situation changes significantly during head maintenance, and that the problem depends on the location of the sensor cable.
 
 The original cable is unshielded and without twisted pair. However, the extruder heater is always running, holding the PWM at 140 degrees (to stabilize for piezoelectric sensor measurements).
 
-Disabling the heater during mesh construction stopped the random sensor activations and reduced its reading repeatability to 0.05 mm. Apparently, the inductive sensor cable is picking up interference from the heater's PWM controller.
+Disabling the heater during meshing stopped the random sensor activations and reduced its reading repeatability to 0.05 mm. Apparently, the inductive sensor cable is picking up interference from the heater's PWM controller.
 
 This problem was on the original unit and on the Phaetus Conch.
 
@@ -17,6 +17,9 @@ This problem was on the original unit and on the Phaetus Conch.
 3. Turn off the extruder heater while the sensor is operating.
 
 ### Disable heater while meshing
+
+Meshing is the primary application of an inductive sensor, which uses a small number of measurements per point (2 by default). Everything else has a higher number of measurements and is therefore less susceptible to interference.
+We'll disable the heater only during meshing.
 
 1. Backup `gcode_macro.cfg`
 2. Edit `gcode_macro.cfg`

--- a/content/inductive-probe-emi/README.md
+++ b/content/inductive-probe-emi/README.md
@@ -57,7 +57,7 @@ deactivate_gcode:
 
 After changes my printers have good repeatability of measurements. I use bigger mesh and lower probe tolerance like on [Better Bed Meshing](../more-accurate-bed-meshing/README.md), and tested what:
 1. No motors tweaks need anymore, but i still use "interpolate: False".
-2. Probe z-speeds can bee increased back to default (5), lift-speed - more then default.
+2. ~~Probe z-speeds can bee increased back to default (5), lift-speed - more then default.~~ Warning: Some people was reported that the sensor is reacting incorrectly, causing the nozzle to touch the bed. We've decided to reduce the speed to 2.5/5. I'm still investigating the cause.
 3. In my case 5 samples per point has "99%" difference in values >0.08 and near measurement points while meshing has adequate difference. I think it safe to decrease probe to 1 sample, but i keep use default 2 for testing. 
 
 ```
@@ -68,9 +68,9 @@ probe_count:11,11
 bicubic_tension:0.3
 
 [smart_effector]
-speed:5
-lift_speed: 10
-samples: 2
+speed:2.5
+lift_speed: 5
+samples: 2 # default - 2
 sample_retract_dist: 10
 samples_tolerance: 0.013
 ```

--- a/content/inductive-probe-emi/README.md
+++ b/content/inductive-probe-emi/README.md
@@ -10,15 +10,24 @@ Disabling the heater during meshing stopped the random sensor activations and re
 
 This problem was on the original unit and on the Phaetus Conch.
 
+## WARNING
+
+Stock inductive probe will fail when heated to ~65c. In this case, the table will ram your head on probe.
+Apparently, cooling the thermal barrier also cools the sensor.
+
 ## Possible solutions
 
 1. Route the sensor cable away from the heater cables. It should also be secured to prevent vibration during printing.
 2. Use a different type of sensor.
-3. Turn off the extruder heater while the sensor is operating.
+3. Turn off the extruder heater while the sensor is operating. But this has some problems described in "warning".
 
-### Disable extruder heater while probing
+### "Disable" extruder heater while probing
 
-Founded what `smart_effector` can run custom gcode before and after probe.
+`smart_effector` can run custom gcode before and after probe.
+
+We cannot turn off extruder - need keep `hotend_fan` enable for cooling stock sensor what controlled by `heater_fan` and i don`t know how enable it manual. So heater will set to 50c - in most cases heater on 50c will turned on with low frequency - table will keep it heated.
+
+50c is default `heater_temp` in `[heater_fan hotend_fan]`.
 
 For changes has 2 options to write changes:
 1. To end of `printer.cfg`
@@ -43,7 +52,7 @@ gcode:
 description: Induction sensor/probe deactivate heaters for EMI
 gcode:
     SET_GCODE_VARIABLE MACRO=_PROBE_HEATERS_ACTIVATE VARIABLE=extruder_temp VALUE={printer["extruder"].target}
-    M104 S0 # extruder
+    M104 S50 # extruder
 
 [smart_effector]
 deactivate_on_each_sample: True
@@ -57,8 +66,8 @@ deactivate_gcode:
 
 After changes my printers have good repeatability of measurements. I use bigger mesh and lower probe tolerance like on [Better Bed Meshing](../more-accurate-bed-meshing/README.md), and tested what:
 1. No motors tweaks need anymore, but i still use "interpolate: False".
-2. ~~Probe z-speeds can bee increased back to default (5), lift-speed - more then default.~~ Warning: Some people was reported that the sensor is reacting incorrectly, causing the nozzle to touch the bed. We've decided to reduce the speed to 2.5/5. I'm still investigating the cause.
-3. In my case 5 samples per point has "99%" difference in values >0.08 and near measurement points while meshing has adequate difference. I think it safe to decrease probe to 1 sample, but i keep use default 2 for testing. 
+2. Probe z-speeds can bee increased back to default (5), lift-speed - more then default.
+3. In my case 5 samples per point has "99%" difference in values >0.08 and near measurement points while meshing has adequate difference. We cannot disable extruder, so `samples` keep to stock value "2".
 
 ```
 # Bigger mesh
@@ -68,8 +77,8 @@ probe_count:11,11
 bicubic_tension:0.3
 
 [smart_effector]
-speed:2.5
-lift_speed: 5
+speed:5
+lift_speed: 10
 samples: 2 # default - 2
 sample_retract_dist: 10
 samples_tolerance: 0.013


### PR DESCRIPTION
I discovered that the stock inductive sensor was picking up interference from the extruder heater PWM, which is always on at 140c. Apparently, this is critically dependent on the relative position of the wiring - it`s not shielded from interference.

After disabling the extruder heater during meshing, the readings and their repeatability improved significantly. Disabling it has no effect on other aspects - it doesn't participate in the measurement when the probe is running, and its geometric stability isn't required.

Disabling the heater is a good method of preventing interference, along with rerouting the wiring.